### PR TITLE
feat(admin): widgets per source

### DIFF
--- a/src/Filament/Admin/Resources/InboundWebhook/Pages/ListInboundWebhooks.php
+++ b/src/Filament/Admin/Resources/InboundWebhook/Pages/ListInboundWebhooks.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Basement\Webhooks\Filament\Admin\Resources\InboundWebhook\Pages;
 
 use Basement\Webhooks\Filament\Admin\Resources\InboundWebhook\InboundWebhookResource;
+use Basement\Webhooks\Filament\Admin\Widgets\InboundWebhookStatsByProviderPercentage;
+use Basement\Webhooks\Filament\Admin\Widgets\InboundWebhookStatsBySource;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -19,6 +21,13 @@ use Filament\Tables\Table;
 final class ListInboundWebhooks extends ListRecords
 {
     protected static string $resource = InboundWebhookResource::class;
+
+    protected function getHeaderWidgets(): array
+    {
+        return [
+            InboundWebhookStatsBySource::make(),
+        ];
+    }
 
     public function table(Table $table): Table
     {

--- a/src/Filament/Admin/Widgets/InboundWebhookStatsBySource.php
+++ b/src/Filament/Admin/Widgets/InboundWebhookStatsBySource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Basement\Webhooks\Filament\Admin\Widgets;
+
+use Basement\Webhooks\Enums\InboundWebhookSource;
+use Basement\Webhooks\Models\InboundWebhook;
+use Filament\Widgets\StatsOverviewWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+class InboundWebhookStatsBySource extends StatsOverviewWidget
+{
+    protected function getStats(): array
+    {
+        return $this->getInboundWebhooksStats();
+    }
+
+    private function getInboundWebhooksStats(): array
+    {
+        $totalWebhooks = InboundWebhook::count();
+        $stats = [];
+
+        foreach (InboundWebhookSource::cases() as $source) {
+            $count = InboundWebhook::where('source', $source->value)->count();
+            $percentage = $totalWebhooks > 0 ? round(($count / $totalWebhooks) * 100, 2) : 0;
+            $stats[] = Stat::make("{$source->name}","{$percentage}%")
+                ->descriptionIcon($source->getIcon())
+                ->description("{$count} de {$totalWebhooks} webhooks")
+                ->color($source->getColor());
+        }
+        return $stats;
+    }
+}

--- a/src/FilamentWebhookPlugin.php
+++ b/src/FilamentWebhookPlugin.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Basement\Webhooks;
 
 use Basement\Webhooks\Filament\Admin\Resources\InboundWebhook\InboundWebhookResource;
+use Basement\Webhooks\Filament\Admin\Widgets\InboundWebhookStatsByProviderPercentage;
+use Basement\Webhooks\Filament\Admin\Widgets\InboundWebhookStatsBySource;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
 
@@ -24,6 +26,9 @@ final class FilamentWebhookPlugin implements Plugin
     {
         $panel->resources([
             InboundWebhookResource::class,
+        ]);
+        $panel->widgets([
+           InboundWebhookStatsBySource::make(),
         ]);
     }
 

--- a/src/Models/InboundWebhook.php
+++ b/src/Models/InboundWebhook.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Basement\Webhooks\Models;
 
+use Basement\Webhooks\Database\Factories\InboundWebhookFactory;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+
 
 final class InboundWebhook extends Model
 {
@@ -29,5 +31,10 @@ final class InboundWebhook extends Model
             'payload' => 'array',
             'source' => config('filament-webhooks.providers_enum'),
         ];
+    }
+
+    protected static function newFactory(): InboundWebhookFactory
+    {
+        return InboundWebhookFactory::new();
     }
 }


### PR DESCRIPTION
This pull request introduces a new stats widget for inbound webhooks, improves dashboard visibility, and enhances model factory support. The main focus is on providing a breakdown of inbound webhook sources for admins and enabling easier testing and seeding of webhook data.

**Dashboard and Widget Improvements**
* Added a new widget, `InboundWebhookStatsBySource`, which displays the percentage and count of inbound webhooks grouped by their source, including icons and colors for clarity. This widget is now shown in the admin list view and registered globally with Filament. 

**Model Enhancements**
* Added a static `newFactory` method to the `InboundWebhook` model, enabling the use of a custom factory for easier testing and data generation.